### PR TITLE
Add --transform tex2html import option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,10 +237,20 @@
 		</dependency>
 		-->
 		<dependency>
+			<groupId>org.jsoup</groupId>
+			<artifactId>jsoup</artifactId>
+			<version>1.8.2</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.8.2</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>xmlunit</groupId>
+			<artifactId>xmlunit</artifactId>
+			<version>1.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.vafer</groupId>

--- a/src/main/java/org/xmlcml/norma/NormaArgProcessor.java
+++ b/src/main/java/org/xmlcml/norma/NormaArgProcessor.java
@@ -41,7 +41,7 @@ import org.xmlcml.xml.XMLUtil;
  *
  * @author pm286
  */
-public class NormaArgProcessor extends DefaultArgProcessor{
+public class NormaArgProcessor extends DefaultArgProcessor {
 
 	private static final String DOT_PNG = ".png";
 	private static final String IMAGE = "image";
@@ -162,11 +162,6 @@ public class NormaArgProcessor extends DefaultArgProcessor{
 		}
 	}
 
-	/** deprecated
-	 *
-	 * @param option
-	 * @param argIterator
-	 */
 	public void parseTransform(ArgumentOption option, ArgIterator argIterator) {
 		List<String> tokens = argIterator.createTokenListUpToNextNonDigitMinus(option);
 		List<String> tokenList = option.processArgs(tokens).getStringValues();
@@ -180,7 +175,7 @@ public class NormaArgProcessor extends DefaultArgProcessor{
 			} else if (TRANSFORM_OPTIONS.contains(token)) {
 				transformList.add(token);
 			} else {
-				LOG.error("Unknown --transform option: "+token);
+				throw new RuntimeException("Unknown --transform option: " + token);
 			}
 		}
 	}

--- a/src/main/java/org/xmlcml/norma/NormaArgProcessor.java
+++ b/src/main/java/org/xmlcml/norma/NormaArgProcessor.java
@@ -35,14 +35,14 @@ import org.xmlcml.cmine.args.StringPair;
 import org.xmlcml.cmine.files.CMDir;
 import org.xmlcml.xml.XMLUtil;
 
-/** 
+/**
  * Processes commandline arguments.
  * for Norma
- * 
+ *
  * @author pm286
  */
 public class NormaArgProcessor extends DefaultArgProcessor{
-	
+
 	private static final String DOT_PNG = ".png";
 	private static final String IMAGE = "image";
 	private static final String PNG = "png";
@@ -50,20 +50,20 @@ public class NormaArgProcessor extends DefaultArgProcessor{
 	static {
 		LOG.setLevel(Level.DEBUG);
 	}
-	
+
 	private static final String STYLESHEET_BY_NAME_XML = "/org/xmlcml/norma/pubstyle/stylesheetByName.xml";
 	private static final String NAME = "name";
 	private static final String XML = "xml";
-	
+
 	public final static String HELP_NORMA = "Norma help";
-	
+
 	private static String RESOURCE_NAME_TOP = "/org/xmlcml/norma";
 	private static String ARGS_RESOURCE = RESOURCE_NAME_TOP+"/"+"args.xml";
-	
+
 	public final static String DOCTYPE = "!DOCTYPE";
 	private static final List<String> TRANSFORM_OPTIONS = Arrays.asList(new String[]{
 			"pdfbox", "pdf2html", "pdf2txt", "pdf2images",
-			"hocr2svg"});
+			"hocr2svg", "tex2html"});
 	// options
 	private List<StringPair> charPairList;
 	private List<String> divList;
@@ -89,7 +89,7 @@ public class NormaArgProcessor extends DefaultArgProcessor{
 	}
 
 	// ============= METHODS =============
-	
+
  	public void parseChars(ArgumentOption option, ArgIterator argIterator) {
 		List<String> tokens = argIterator.createTokenListUpToNextNonDigitMinus(option);
 		charPairList = option.processArgs(tokens).getStringPairValues();
@@ -103,7 +103,7 @@ public class NormaArgProcessor extends DefaultArgProcessor{
 		List<String> tokens = argIterator.createTokenListUpToNextNonDigitMinus(option);
 		namePairList = option.processArgs(tokens).getStringPairValues();
 	}
-	
+
 	public void parsePubstyle(ArgumentOption option, ArgIterator argIterator) {
 		List<String> tokens = argIterator.createTokenListUpToNextNonDigitMinus(option);
 		if (tokens.size() == 0) {
@@ -139,7 +139,7 @@ public class NormaArgProcessor extends DefaultArgProcessor{
 	}
 
 	/** deprecated // use transform instead
-	 * 
+	 *
 	 * @param option
 	 * @param argIterator
 	 */
@@ -163,7 +163,7 @@ public class NormaArgProcessor extends DefaultArgProcessor{
 	}
 
 	/** deprecated
-	 * 
+	 *
 	 * @param option
 	 * @param argIterator
 	 */
@@ -180,7 +180,7 @@ public class NormaArgProcessor extends DefaultArgProcessor{
 			} else if (TRANSFORM_OPTIONS.contains(token)) {
 				transformList.add(token);
 			} else {
-				LOG.error("Cannot process transform token: "+token);
+				LOG.error("Unknown --transform option: "+token);
 			}
 		}
 	}
@@ -197,9 +197,9 @@ public class NormaArgProcessor extends DefaultArgProcessor{
 				);
 		super.printHelp();
 	}
-	
+
 	// ===========run===============
-	
+
 	public void transform(ArgumentOption option) {
 		// deprecated so
 		runTransform(option);
@@ -221,7 +221,7 @@ public class NormaArgProcessor extends DefaultArgProcessor{
 	public void runTest(ArgumentOption option) {
 		LOG.debug("RUN_TEST "+"is a dummy");
 	}
-		
+
 
 	// =============output=============
 	public void outputMethod(ArgumentOption option) {
@@ -268,7 +268,7 @@ public class NormaArgProcessor extends DefaultArgProcessor{
 	}
 
 	// ==========================
-	
+
 	private void ensureXslDocumentList() {
 		if (xslDocumentList == null) {
 			xslDocumentList = new ArrayList<org.w3c.dom.Document>();
@@ -366,16 +366,16 @@ public class NormaArgProcessor extends DefaultArgProcessor{
 			FileUtils.forceMkdir(reservedDir);
 		} catch (IOException e) {
 			throw new RuntimeException("Cannot make directory: "+reservedFilename+" "+e);
-		}  
+		}
 		String name = FilenameUtils.getName(filename);
 		try {
 			File outFile = new File(reservedDir, name);
 			FileUtils.copyFile(new File(filename), outFile);
 		} catch (IOException e) {
 			throw new RuntimeException("Cannot copy file: "+filename+" to "+reservedDir+" / "+e);
-		}  
+		}
 		LOG.debug("created "+name+" in "+reservedDir);
-		
+
 	}
 
 	private CMDir createCMDir(String dirName) {
@@ -399,7 +399,7 @@ public class NormaArgProcessor extends DefaultArgProcessor{
 	}
 
 	private org.w3c.dom.Document createW3CStylesheetDocument(String xslName) {
-		DocumentBuilder db = createDocumentBuilder(); 
+		DocumentBuilder db = createDocumentBuilder();
 		String stylesheetResourceName = replaceCodeIfPossible(xslName);
 		org.w3c.dom.Document stylesheetDocument = readAsResource(db, stylesheetResourceName);
 		// if fails, try as file
@@ -495,12 +495,12 @@ public class NormaArgProcessor extends DefaultArgProcessor{
 	public boolean isStandalone() {
 		return standalone;
 	}
-	
+
 	@Override
 	/** parse args and resolve their dependencies.
-	 * 
+	 *
 	 * (don't run any argument actions)
-	 * 
+	 *
 	 */
 	public void parseArgs(String[] args) {
 		super.parseArgs(args);

--- a/src/main/java/org/xmlcml/norma/NormaTransformer.java
+++ b/src/main/java/org/xmlcml/norma/NormaTransformer.java
@@ -24,10 +24,11 @@ import org.xmlcml.html.HtmlElement;
 import org.xmlcml.norma.image.ocr.HOCRReader;
 import org.xmlcml.norma.input.pdf.PDF2ImagesConverter;
 import org.xmlcml.norma.input.pdf.PDF2TXTConverter;
+import org.xmlcml.norma.input.tex.TEX2HTMLConverter;
 import org.xmlcml.norma.util.TransformerWrapper;
 
 public class NormaTransformer {
-	
+
 	private static final Logger LOG = Logger.getLogger(NormaTransformer.class);
 	static {
 		LOG.setLevel(Level.DEBUG);
@@ -39,10 +40,12 @@ public class NormaTransformer {
 	private static final String PDF2TXT = "pdf2txt";
 	private static final String PDF2IMAGES = "pdf2images";
 	private static final String TXT2HTML = "txt2html";
-	
+	private static final String TEX2HTML = "tex2html";
+
 	private NormaArgProcessor normaArgProcessor;
 	private File inputFile;
 	private Map<org.w3c.dom.Document, TransformerWrapper> transformerWrapperByStylesheetMap;
+
 	String outputTxt;
 	List<String> xmlStringList;
 	List<Pair<String, BufferedImage>> serialImageList;
@@ -54,12 +57,12 @@ public class NormaTransformer {
 	}
 
 	/** transforms currentCMDir.
-	 * 
+	 *
 	 * output is either:
 	 *   outputTxt (from PDF2TXT)
 	 *   htmlElement (from PDF/TXT2HTML)
 	 *   xmlStringList (from XSL transformation(s))
-	 *   
+	 *
 	 * @param option
 	 */
 	void transform(ArgumentOption option) {
@@ -73,8 +76,7 @@ public class NormaTransformer {
 		xmlStringList = null;
 		serialImageList = null;
 		if (option.getVerbose().equals(XSL) || option.getVerbose().equals(TRANSFORM)) {
-			if (false) {				
-			} else if (HOCR2SVG.equals(option.getStringValue())) {
+			if (HOCR2SVG.equals(option.getStringValue())) {
 				svgElement = applyHOCR2SVGToInputFile(inputFile);
 			} else if (PDF2TXT.equals(option.getStringValue())) {
 				outputTxt = applyPDF2TXTToCMLDir();
@@ -85,6 +87,8 @@ public class NormaTransformer {
 			} else if (PDF2HTML.equals(option.getStringValue())) {
 				applyPDF2TXTToCMLDir();
 				htmlElement = convertToHTML(outputTxt);
+			} else if (TEX2HTML.equals(option.getStringValue())) {
+				xmlStringList = convertTeXToHTML(inputFile);
 			} else {
 				xmlStringList = applyXSLDocumentListToCurrentCMDir();
 			}
@@ -135,6 +139,19 @@ public class NormaTransformer {
 		return htmlElement;
 	}
 
+	private List<String> convertTeXToHTML(File inputFile) {
+		TEX2HTMLConverter converter = new TEX2HTMLConverter();
+		try {
+			List<String> result = new ArrayList<String>();
+			result.add(converter.convertTeXToHTML(inputFile));
+			return result;
+		} catch (InterruptedException e) {
+			throw new RuntimeException("Failed to convert TeX to HTML", e);
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to convert TeX to HTML", e);
+		}
+	}
+
 	private HtmlElement convertToHTML(String txt) {
 		HtmlElement element = null;
 		return element;
@@ -153,7 +170,7 @@ public class NormaTransformer {
 		}
 		return xmlStringList;
 	}
-	
+
 	private String transform(org.w3c.dom.Document xslDocument) throws IOException {
 		TransformerWrapper transformerWrapper = getOrCreateTransformerWrapperForStylesheet(xslDocument);
 		String xmlString = null;
@@ -182,9 +199,9 @@ public class NormaTransformer {
 		}
 		return transformerWrapper;
 	}
-	
+
 	// from Input wrapper, maybe obsolete
-	
+
 	// FIXME
 	/** this is not called and probably should be*/
 	private HtmlElement transform(NormaArgProcessor argProcessor) throws Exception {
@@ -212,7 +229,7 @@ public class NormaTransformer {
 
 
 //	/** maybe move to Pubstyle later.
-//	 * 
+//	 *
 //	 * @param pubstyle
 //	 */
 //	private void normalizeToXHTML() throws Exception {
@@ -237,7 +254,7 @@ public class NormaTransformer {
 //			throw new RuntimeException("cannot convert "+getInputFormat()+" "+inputName, e);
 //		}
 //	}
-	
+
 
 	private void transformXmlToHTML() throws Exception {
 //		ensureXslDocumentList();
@@ -248,7 +265,7 @@ public class NormaTransformer {
 //			throw new RuntimeException("No stylesheet file/s given");
 //		} else if (outputFile == null) {
 //			throw new RuntimeException("No output file given");
-//		} 
+//		}
 //		if (stylesheetDocumentList.size() >1) {
 //			throw new RuntimeException("Only one stylesheet allowed at present");
 //		}
@@ -266,10 +283,10 @@ public class NormaTransformer {
 //			}
 //		}
 //	}
-	
+
 	// ============
-	
-	
+
+
 
 
 	public String getOutputTxt() {
@@ -281,12 +298,12 @@ public class NormaTransformer {
 	}
 
 	/** ordered list of title+image.
-	 * 
+	 *
 	 * title are of form "image<page>.<serial>.Img<img>"
 	 * page is PD page number (base 1)
 	 * serial is serial index of image (includes duplication)
 	 * img is unique image serial
-	 * 
+	 *
 	 * @return
 	 */
 	public List<Pair<String, BufferedImage>> getImageList() {

--- a/src/main/java/org/xmlcml/norma/input/tex/TEX2HTMLConverter.java
+++ b/src/main/java/org/xmlcml/norma/input/tex/TEX2HTMLConverter.java
@@ -1,0 +1,58 @@
+package org.xmlcml.norma.input.tex;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.commons.io.IOUtils;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Entities;
+import org.jsoup.parser.Parser;
+
+/**
+ * Converts TeX input to HTML 5 using LaTeXML
+ */
+public class TEX2HTMLConverter {
+    private static final Logger LOG = Logger.getLogger(TEX2HTMLConverter.class);
+
+    static {
+        LOG.setLevel(Level.DEBUG);
+    }
+
+    private String convertHTMLToXHTML(String html) {
+        Document htmlDocument = Parser.parse(html, "");
+        Document.OutputSettings outputSettings = htmlDocument.outputSettings().clone();
+        outputSettings.escapeMode(Entities.EscapeMode.xhtml);
+        outputSettings.syntax(Document.OutputSettings.Syntax.xml);
+        htmlDocument.outputSettings(outputSettings);
+        return htmlDocument.html();
+    }
+
+    public String convertTeXToHTML(File input) throws IOException, InterruptedException {
+        FileInputStream inputStream = new FileInputStream(input);
+
+        // latexml performs the initial TeX => XML conversion,
+        ProcessBuilder latexMLBuilder = new ProcessBuilder("latexml", "-", "--quiet");
+        latexMLBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
+        Process latexMLProc = latexMLBuilder.start();
+        IOUtils.copy(inputStream, latexMLProc.getOutputStream());
+        latexMLProc.getOutputStream().close();
+
+        LOG.debug("Processing input with LaTeXML");
+
+        // latexmlpost transforms the resulting XML to HTML 5
+        ProcessBuilder latexMLPostBuilder = new ProcessBuilder("latexmlpost", "-", "--format=html5");
+        latexMLPostBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
+
+        Process latexMLPostProc = latexMLPostBuilder.start();
+        IOUtils.copy(latexMLProc.getInputStream(), latexMLPostProc.getOutputStream());
+        latexMLPostProc.getOutputStream().close();
+
+        String html = IOUtils.toString(latexMLPostProc.getInputStream(), StandardCharsets.UTF_8);
+        return convertHTMLToXHTML(html);
+    }
+}

--- a/src/test/java/org/xmlcml/norma/InputTest.java
+++ b/src/test/java/org/xmlcml/norma/InputTest.java
@@ -1,6 +1,7 @@
 package org.xmlcml.norma;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,6 +29,10 @@ public class InputTest {
 	private static final Logger LOG = Logger.getLogger(InputTest.class);
 	static {
 		LOG.setLevel(Level.DEBUG);
+	}
+
+	private String testFilePath(String path) {
+		return Fixtures.TEST_NORMA_DIR + "/" + path;
 	}
 	
 	@Test
@@ -326,12 +331,21 @@ public class InputTest {
 		norma = new Norma();
 		norma.run(args);
 	}
-	
+
 	@Test
-	public void testOutputWorks() {
-		
+	public void testTeX2HTMLTransform() throws IOException {
+		File tempDir = FileUtils.getTempDirectory();
+		FileUtils.copyFile(new File(testFilePath("tex/sample.tex")), new File(tempDir + "/fulltext.tex"));
+
+		String args;
+		Norma norma = new Norma();
+		args =
+				"-q " + tempDir.toString()
+				+ " -i fulltext.tex"
+				+ " -o scholarly.html"
+				+ " --transform tex2html";
+		norma.run(args);
 	}
-	
 	
 	@Test
 	// FIXME

--- a/src/test/java/org/xmlcml/norma/input/tex/TEX2HTMLConverterTest.java
+++ b/src/test/java/org/xmlcml/norma/input/tex/TEX2HTMLConverterTest.java
@@ -1,0 +1,39 @@
+package org.xmlcml.norma.input.tex;
+
+import org.apache.commons.io.IOUtils;
+import org.custommonkey.xmlunit.Diff;
+import org.custommonkey.xmlunit.IgnoreTextAndAttributeValuesDifferenceListener;
+import org.custommonkey.xmlunit.XMLTestCase;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+import org.xmlcml.norma.Fixtures;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class TEX2HTMLConverterTest extends XMLTestCase {
+    @Test
+    public void testConvertTex() throws InterruptedException, IOException, SAXException {
+        // LaTeXML includes comments about the generator which vary on each run.
+        // Ignore these.
+        XMLUnit.setIgnoreComments(true);
+
+        TEX2HTMLConverter converter = new TEX2HTMLConverter();
+        File texFile = new File(Fixtures.TEST_NORMA_DIR + "/tex/sample.tex");
+        File expectedXMLFile = new File(Fixtures.TEST_NORMA_DIR + "/tex/sample.tex.xhtml");
+        String actualXML = converter.convertTeXToHTML(texFile);
+        String expectedXML = new String(IOUtils.toByteArray(new FileInputStream(expectedXMLFile)));
+        Diff diff = new Diff(expectedXML, actualXML);
+
+        // LaTeXML output includes certain attributes/values which differ on each run.
+        // This current test only verifies the structure of the markup
+        diff.overrideDifferenceListener(new IgnoreTextAndAttributeValuesDifferenceListener());
+
+        assertXMLEqual(diff, true);
+    }
+}

--- a/src/test/resources/org/xmlcml/norma/tex/sample.tex
+++ b/src/test/resources/org/xmlcml/norma/tex/sample.tex
@@ -1,0 +1,175 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Journal Article
+% LaTeX Template
+% Version 1.3 (9/9/13)
+%
+% This template has been downloaded from:
+% http://www.LaTeXTemplates.com
+%
+% Original author:
+% Frits Wenneker (http://www.howtotex.com)
+%
+% License:
+% CC BY-NC-SA 3.0 (http://creativecommons.org/licenses/by-nc-sa/3.0/)
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%----------------------------------------------------------------------------------------
+%	PACKAGES AND OTHER DOCUMENT CONFIGURATIONS
+%----------------------------------------------------------------------------------------
+
+\documentclass[twoside]{article}
+
+\usepackage{lipsum} % Package to generate dummy text throughout this template
+
+\usepackage[sc]{mathpazo} % Use the Palatino font
+\usepackage[T1]{fontenc} % Use 8-bit encoding that has 256 glyphs
+\linespread{1.05} % Line spacing - Palatino needs more space between lines
+\usepackage{microtype} % Slightly tweak font spacing for aesthetics
+
+\usepackage[hmarginratio=1:1,top=32mm,columnsep=20pt]{geometry} % Document margins
+\usepackage{multicol} % Used for the two-column layout of the document
+\usepackage[hang, small,labelfont=bf,up,textfont=it,up]{caption} % Custom captions under/above floats in tables or figures
+\usepackage{booktabs} % Horizontal rules in tables
+\usepackage{float} % Required for tables and figures in the multi-column environment - they need to be placed in specific locations with the [H] (e.g. \begin{table}[H])
+\usepackage{hyperref} % For hyperlinks in the PDF
+
+\usepackage{lettrine} % The lettrine is the first enlarged letter at the beginning of the text
+\usepackage{paralist} % Used for the compactitem environment which makes bullet points with less space between them
+
+\usepackage{abstract} % Allows abstract customization
+\renewcommand{\abstractnamefont}{\normalfont\bfseries} % Set the "Abstract" text to bold
+\renewcommand{\abstracttextfont}{\normalfont\small\itshape} % Set the abstract itself to small italic text
+
+\usepackage{titlesec} % Allows customization of titles
+\renewcommand\thesection{\Roman{section}} % Roman numerals for the sections
+\renewcommand\thesubsection{\Roman{subsection}} % Roman numerals for subsections
+\titleformat{\section}[block]{\large\scshape\centering}{\thesection.}{1em}{} % Change the look of the section titles
+\titleformat{\subsection}[block]{\large}{\thesubsection.}{1em}{} % Change the look of the section titles
+
+\usepackage{fancyhdr} % Headers and footers
+\pagestyle{fancy} % All pages have headers and footers
+\fancyhead{} % Blank out the default header
+\fancyfoot{} % Blank out the default footer
+\fancyhead[C]{Running title $\bullet$ November 2012 $\bullet$ Vol. XXI, No. 1} % Custom header text
+\fancyfoot[RO,LE]{\thepage} % Custom footer text
+
+%----------------------------------------------------------------------------------------
+%	TITLE SECTION
+%----------------------------------------------------------------------------------------
+
+\title{\vspace{-15mm}\fontsize{24pt}{10pt}\selectfont\textbf{Article Title}} % Article title
+
+\author{
+\large
+\textsc{John Smith}\thanks{A thank you or further information}\\[2mm] % Your name
+\normalsize University of California \\ % Your institution
+\normalsize \href{mailto:john@smith.com}{john@smith.com} % Your email address
+\vspace{-5mm}
+}
+\date{}
+
+%----------------------------------------------------------------------------------------
+
+\begin{document}
+
+\maketitle % Insert title
+
+\thispagestyle{fancy} % All pages have headers and footers
+
+%----------------------------------------------------------------------------------------
+%	ABSTRACT
+%----------------------------------------------------------------------------------------
+
+\begin{abstract}
+
+\noindent \lipsum[1] % Dummy abstract text
+
+\end{abstract}
+
+%----------------------------------------------------------------------------------------
+%	ARTICLE CONTENTS
+%----------------------------------------------------------------------------------------
+
+\begin{multicols}{2} % Two-column layout throughout the main article text
+
+\section{Introduction}
+
+\lettrine[nindent=0em,lines=3]{L} orem ipsum dolor sit amet, consectetur adipiscing elit.
+\lipsum[2-3] % Dummy text
+
+%------------------------------------------------
+
+\section{Methods}
+
+Maecenas sed ultricies felis. Sed imperdiet dictum arcu a egestas. 
+\begin{compactitem}
+\item Donec dolor arcu, rutrum id molestie in, viverra sed diam
+\item Curabitur feugiat
+\item turpis sed auctor facilisis
+\item arcu eros accumsan lorem, at posuere mi diam sit amet tortor
+\item Fusce fermentum, mi sit amet euismod rutrum
+\item sem lorem molestie diam, iaculis aliquet sapien tortor non nisi
+\item Pellentesque bibendum pretium aliquet
+\end{compactitem}
+\lipsum[4] % Dummy text
+
+%------------------------------------------------
+
+\section{Results}
+
+\begin{table}[H]
+\caption{Example table}
+\centering
+\begin{tabular}{llr}
+\toprule
+\multicolumn{2}{c}{Name} \\
+\cmidrule(r){1-2}
+First name & Last Name & Grade \\
+\midrule
+John & Doe & $7.5$ \\
+Richard & Miles & $2$ \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\lipsum[5] % Dummy text
+
+\begin{equation}
+\label{eq:emc}
+e = mc^2
+\end{equation}
+
+\lipsum[6] % Dummy text
+
+%------------------------------------------------
+
+\section{Discussion}
+
+\subsection{Subsection One}
+
+\lipsum[7] % Dummy text
+
+\subsection{Subsection Two}
+
+\lipsum[8] % Dummy text
+
+%----------------------------------------------------------------------------------------
+%	REFERENCE LIST
+%----------------------------------------------------------------------------------------
+
+\begin{thebibliography}{99} % Bibliography - this is intentionally simple in this template
+
+\bibitem[Figueredo and Wolf, 2009]{Figueredo:2009dg}
+Figueredo, A.~J. and Wolf, P. S.~A. (2009).
+\newblock Assortative pairing and life history strategy - a cross-cultural
+  study.
+\newblock {\em Human Nature}, 20:317--330.
+ 
+\end{thebibliography}
+
+%----------------------------------------------------------------------------------------
+
+\end{multicols}
+
+\end{document}

--- a/src/test/resources/org/xmlcml/norma/tex/sample.tex.xhtml
+++ b/src/test/resources/org/xmlcml/norma/tex/sample.tex.xhtml
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html>
+ <head> 
+  <title>Article Title</title> 
+  <!--Generated on Fri Jun  5 15:52:03 2015 by LaTeXML (version 0.8.0) http://dlmf.nist.gov/LaTeXML/.--> 
+  <!--Document created on .--> 
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /> 
+  <link rel="stylesheet" href="/home/robert/other/norma/LaTeXML.css" type="text/css" /> 
+  <link rel="stylesheet" href="/home/robert/other/norma/ltx-article.css" type="text/css" /> 
+ </head> 
+ <body> 
+  <div class="ltx_page_main"> 
+   <div class="ltx_page_content"> 
+    <section class="ltx_document ltx_authors_1line"> 
+     <h1 class="ltx_title ltx_font_bold ltx_title_document">Article Title</h1> 
+     <div class="ltx_authors"> 
+      <span class="ltx_creator ltx_role_author"> <span class="ltx_personname"><span class="ltx_text ltx_font_smallcaps ltx_font_large">John Smith <br class="ltx_break" /><span class="ltx_text ltx_font_upright"> </span></span>University of California <br class="ltx_break" /><a href="mailto:john@smith.com" title="" class="ltx_ref">john@smith.com</a> </span><span class="ltx_author_notes"><span><span class="ltx_text ltx_font_large">A thank you or further information</span></span></span></span> 
+     </div> 
+     <div class="ltx_date ltx_role_creation"></div> 
+     <div class="ltx_abstract"> 
+      <h6 class="ltx_title ltx_title_abstract">Abstract</h6> 
+      <span class="ltx_ERROR undefined">\lipsum</span> 
+      <p class="ltx_p">[1] </p> 
+     </div> 
+     <span class="ltx_ERROR undefined">\titleformat</span> 
+     <section id="S1" class="ltx_section"> 
+      <h1 class="ltx_title ltx_title_section"></h1> 
+      <span class="ltx_tag ltx_tag_document">I</span> 
+      <div id="S1.p1" class="ltx_para"> 
+       <p class="ltx_p">[block]I.1em<span class="ltx_ERROR undefined">\titleformat</span></p> 
+      </div> 
+      <section id="S1.SS1" class="ltx_subsection"> 
+       <h1 class="ltx_title ltx_title_subsection"></h1> 
+       <span class="ltx_tag ltx_tag_section">I</span> 
+       <div id="S1.SS1.p1" class="ltx_para"> 
+        <p class="ltx_p">[block]I.1em</p> 
+       </div> 
+       <span class="ltx_ERROR undefined">\fancyhead</span>
+       <span class="ltx_ERROR undefined">\fancyfoot</span>
+       <span class="ltx_ERROR undefined">\fancyhead</span> 
+       <div id="S1.SS1.p2" class="ltx_para"> 
+        <p class="ltx_p">[C]Runningtitle
+         <math id="S1.SS1.p2.m1" class="ltx_Math" alttext="\bullet" display="inline">
+          <semantics>
+           <mo>
+            ∙
+           </mo>
+           <annotation encoding="application/x-tex">
+            \bullet
+           </annotation>
+          </semantics>
+         </math>November2012
+         <math id="S1.SS1.p2.m2" class="ltx_Math" alttext="\bullet" display="inline">
+          <semantics>
+           <mo>
+            ∙
+           </mo>
+           <annotation encoding="application/x-tex">
+            \bullet
+           </annotation>
+          </semantics>
+         </math>Vol.XXI,No.1<span class="ltx_ERROR undefined">\fancyfoot</span>[RO,LE]0</p> 
+       </div> 
+      </section> 
+     </section> 
+     <section id="S2" class="ltx_section"> 
+      <h1 class="ltx_title ltx_title_section"> <span class="ltx_tag ltx_tag_section">II </span>Introduction</h1> 
+      <span class="ltx_ERROR undefined">\lettrine</span> 
+      <div id="S2.p1" class="ltx_para"> 
+       <p class="ltx_p">[nindent=0em,lines=3]L orem ipsum dolor sit amet, consectetur adipiscing elit. <span class="ltx_ERROR undefined">\lipsum</span>[2-3] </p> 
+      </div> 
+     </section> 
+     <section id="S3" class="ltx_section"> 
+      <h1 class="ltx_title ltx_title_section"> <span class="ltx_tag ltx_tag_section">III </span>Methods</h1> 
+      <div id="S3.p1" class="ltx_para"> 
+       <p class="ltx_p">Maecenas sed ultricies felis. Sed imperdiet dictum arcu a egestas.</p> 
+       <ul id="I1" class="ltx_itemize"> 
+        <li id="I1.i1" class="ltx_item" style="list-style-type:none;"> <span class="ltx_tag ltx_tag_itemize">•</span> 
+         <div id="I1.i1.p1" class="ltx_para"> 
+          <p class="ltx_p">Donec dolor arcu, rutrum id molestie in, viverra sed diam</p> 
+         </div> </li> 
+        <li id="I1.i2" class="ltx_item" style="list-style-type:none;"> <span class="ltx_tag ltx_tag_itemize">•</span> 
+         <div id="I1.i2.p1" class="ltx_para"> 
+          <p class="ltx_p">Curabitur feugiat</p> 
+         </div> </li> 
+        <li id="I1.i3" class="ltx_item" style="list-style-type:none;"> <span class="ltx_tag ltx_tag_itemize">•</span> 
+         <div id="I1.i3.p1" class="ltx_para"> 
+          <p class="ltx_p">turpis sed auctor facilisis</p> 
+         </div> </li> 
+        <li id="I1.i4" class="ltx_item" style="list-style-type:none;"> <span class="ltx_tag ltx_tag_itemize">•</span> 
+         <div id="I1.i4.p1" class="ltx_para"> 
+          <p class="ltx_p">arcu eros accumsan lorem, at posuere mi diam sit amet tortor</p> 
+         </div> </li> 
+        <li id="I1.i5" class="ltx_item" style="list-style-type:none;"> <span class="ltx_tag ltx_tag_itemize">•</span> 
+         <div id="I1.i5.p1" class="ltx_para"> 
+          <p class="ltx_p">Fusce fermentum, mi sit amet euismod rutrum</p> 
+         </div> </li> 
+        <li id="I1.i6" class="ltx_item" style="list-style-type:none;"> <span class="ltx_tag ltx_tag_itemize">•</span> 
+         <div id="I1.i6.p1" class="ltx_para"> 
+          <p class="ltx_p">sem lorem molestie diam, iaculis aliquet sapien tortor non nisi</p> 
+         </div> </li> 
+        <li id="I1.i7" class="ltx_item" style="list-style-type:none;"> <span class="ltx_tag ltx_tag_itemize">•</span> 
+         <div id="I1.i7.p1" class="ltx_para"> 
+          <p class="ltx_p">Pellentesque bibendum pretium aliquet</p> 
+         </div> </li> 
+       </ul> 
+       <span class="ltx_ERROR undefined">\lipsum</span> 
+       <p class="ltx_p">[4] </p> 
+      </div> 
+     </section> 
+     <section id="S4" class="ltx_section"> 
+      <h1 class="ltx_title ltx_title_section"> <span class="ltx_tag ltx_tag_section">IV </span>Results</h1> 
+      <figure id="S4.T1" class="ltx_table"> 
+       <figcaption class="ltx_caption ltx_centering">
+        <span class="ltx_tag ltx_tag_table">Table 1: </span>Example table
+       </figcaption> 
+       <table class="ltx_tabular ltx_centering ltx_align_middle"> 
+        <tbody class="ltx_tbody"> 
+         <tr class="ltx_tr"> 
+          <th class="ltx_td ltx_align_center ltx_border_tt" colspan="2">Name</th> 
+          <td class="ltx_td ltx_border_tt"></td> 
+         </tr> 
+         <tr class="ltx_tr"> 
+          <th class="ltx_td ltx_align_left ltx_border_t">First name</th> 
+          <th class="ltx_td ltx_align_left ltx_border_t">Last Name</th> 
+          <th class="ltx_td ltx_align_right ltx_border_t">Grade</th> 
+         </tr> 
+         <tr class="ltx_tr"> 
+          <td class="ltx_td ltx_align_left ltx_border_t">John</td> 
+          <td class="ltx_td ltx_align_left ltx_border_t">Doe</td> 
+          <td class="ltx_td ltx_align_right ltx_border_t">
+           <math id="S4.T1.m1" class="ltx_Math" alttext="7.5" display="inline">
+            <semantics>
+             <mn>
+              7.5
+             </mn>
+             <annotation encoding="application/x-tex">
+              7.5
+             </annotation>
+            </semantics>
+           </math></td> 
+         </tr> 
+         <tr class="ltx_tr"> 
+          <td class="ltx_td ltx_align_left ltx_border_bb">Richard</td> 
+          <td class="ltx_td ltx_align_left ltx_border_bb">Miles</td> 
+          <td class="ltx_td ltx_align_right ltx_border_bb">
+           <math id="S4.T1.m2" class="ltx_Math" alttext="2" display="inline">
+            <semantics>
+             <mn>
+              2
+             </mn>
+             <annotation encoding="application/x-tex">
+              2
+             </annotation>
+            </semantics>
+           </math></td> 
+         </tr> 
+        </tbody> 
+       </table> 
+      </figure>
+      <span class="ltx_ERROR undefined">\lipsum</span> 
+      <div id="S4.p1" class="ltx_para"> 
+       <p class="ltx_p">[5] </p> 
+      </div> 
+      <div id="S4.p2" class="ltx_para"> 
+       <table id="S4.E1" class="ltx_equation"> 
+        <tbody>
+         <tr class="ltx_equation ltx_align_baseline"> 
+          <td class="ltx_eqn_pad"></td> 
+          <td class="ltx_align_center">
+           <math id="S4.E1.m1" class="ltx_Math" alttext="e=mc^{2}" display="block">
+            <semantics>
+             <mrow>
+              <mi>
+               e
+              </mi>
+              <mo>
+               =
+              </mo>
+              <mrow>
+               <mi>
+                m
+               </mi>
+               <mo>
+                ⁢
+               </mo>
+               <msup>
+                <mi>
+                 c
+                </mi>
+                <mn>
+                 2
+                </mn>
+               </msup>
+              </mrow>
+             </mrow>
+             <annotation encoding="application/x-tex">
+              e=mc^{2}
+             </annotation>
+            </semantics>
+           </math></td> 
+          <td class="ltx_eqn_pad"></td> 
+          <td rowspan="1" class="ltx_align_middle ltx_align_right"><span class="ltx_tag ltx_tag_equation">(1)</span></td> 
+         </tr> 
+        </tbody>
+       </table> 
+      </div> 
+      <span class="ltx_ERROR undefined">\lipsum</span> 
+      <div id="S4.p3" class="ltx_para"> 
+       <p class="ltx_p">[6] </p> 
+      </div> 
+     </section> 
+     <section id="S5" class="ltx_section"> 
+      <h1 class="ltx_title ltx_title_section"> <span class="ltx_tag ltx_tag_section">V </span>Discussion</h1> 
+      <section id="S5.SS1" class="ltx_subsection"> 
+       <h1 class="ltx_title ltx_title_subsection"> <span class="ltx_tag ltx_tag_subsection">I </span>Subsection One</h1> 
+       <span class="ltx_ERROR undefined">\lipsum</span> 
+       <div id="S5.SS1.p1" class="ltx_para"> 
+        <p class="ltx_p">[7] </p> 
+       </div> 
+      </section> 
+      <section id="S5.SS2" class="ltx_subsection"> 
+       <h1 class="ltx_title ltx_title_subsection"> <span class="ltx_tag ltx_tag_subsection">II </span>Subsection Two</h1> 
+       <span class="ltx_ERROR undefined">\lipsum</span> 
+       <div id="S5.SS2.p1" class="ltx_para"> 
+        <p class="ltx_p">[8] </p> 
+       </div> 
+      </section> 
+     </section> 
+     <section id="bib" class="ltx_bibliography"> 
+      <h1 class="ltx_title ltx_title_bibliography">References</h1> 
+      <ul class="ltx_biblist"> 
+       <li id="bib.bibx1" class="ltx_bibitem"> <span class="ltx_bibtag ltx_role_refnum">Figueredo and Wolf, 2009</span> <span class="ltx_bibblock"> Figueredo, A. J. and Wolf, P. S. A. (2009). </span> <span class="ltx_bibblock">Assortative pairing and life history strategy - a cross-cultural study. </span> <span class="ltx_bibblock"><span class="ltx_text ltx_font_italic">Human Nature</span>, 20:317–330. </span> </li> 
+      </ul> 
+     </section> 
+    </section> 
+   </div> 
+   <footer class="ltx_page_footer"> 
+    <div class="ltx_page_logo">
+     Generated on Fri Jun 5 15:52:03 2015 by 
+     <a href="http://dlmf.nist.gov/LaTeXML/">LaTeXML <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAYAAAD5YeaVAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wKExQZLWTEaOUAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAdpJREFUKM9tkL+L2nAARz9fPZNCKFapUn8kyI0e4iRHSR1Kb8ng0lJw6FYHFwv2LwhOpcWxTjeUunYqOmqd6hEoRDhtDWdA8ApRYsSUCDHNt5ul13vz4w0vWCgUnnEc975arX6ORqN3VqtVZbfbTQC4uEHANM3jSqXymFI6yWazP2KxWAXAL9zCUa1Wy2tXVxheKA9YNoR8Pt+aTqe4FVVVvz05O6MBhqUIBGk8Hn8HAOVy+T+XLJfLS4ZhTiRJgqIoVBRFIoric47jPnmeB1mW/9rr9ZpSSn3Lsmir1fJZlqWlUonKsvwWwD8ymc/nXwVBeLjf7xEKhdBut9Hr9WgmkyGEkJwsy5eHG5vN5g0AKIoCAEgkEkin0wQAfN9/cXPdheu6P33fBwB4ngcAcByHJpPJl+fn54mD3Gg0NrquXxeLRQAAwzAYj8cwTZPwPH9/sVg8PXweDAauqqr2cDjEer1GJBLBZDJBs9mE4zjwfZ85lAGg2+06hmGgXq+j3+/DsixYlgVN03a9Xu8jgCNCyIegIAgx13Vfd7vdu+FweG8YRkjXdWy329+dTgeSJD3ieZ7RNO0VAXAPwDEAO5VKndi2fWrb9jWl9Esul6PZbDY9Go1OZ7PZ9z/lyuD3OozU2wAAAABJRU5ErkJggg==" alt="[LOGO]" /></a> 
+    </div>
+   </footer> 
+  </div>   
+ </body>
+</html>


### PR DESCRIPTION
This adds an option to convert fulltext in LaTeX format to Scholarly XHTML using LaTeXML. The main TeX file for the article is expected to be named fulltext.tex in the ContentMine input directory.

This requires https://github.com/petermr/cmine/pull/1
